### PR TITLE
Refresh idempotency key and ignore unsupported capabilities

### DIFF
--- a/v2/api-validator/package-lock.json
+++ b/v2/api-validator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fireblocks-netlink-v2-api-validator",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fireblocks-netlink-v2-api-validator",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^10.1.0",

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -52,7 +52,7 @@ describe('Test request bodies missing one required property', () => {
             const badBody = _.cloneDeep(goodBody);
             deleteDeepProperty(badBody, propertyPath);
 
-            if (badBody?.['idempotencyKey']) {
+            if (Object.prototype.hasOwnProperty.call(badBody, 'idempotencyKey')) {
               badBody['idempotencyKey'] = randomUUID();
             }
 

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -2,30 +2,28 @@ import _ from 'lodash';
 import { JsonValue } from 'type-fest';
 import ApiClient from '../../src/client';
 import { JSONSchemaFaker, Schema } from 'json-schema-faker';
-import {EndpointSchema, getAllEndpointSchemas} from '../../src/schemas';
+import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
 import { deleteDeepProperty, getPropertyPaths } from '../property-extraction';
-import {ApiComponents, ApiError, BadRequestError, RequestPart} from '../../src/client/generated';
-import {AssetsDirectory} from "../utils/assets-directory";
-import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
-import {getRequestBody} from "../../src/client/generated/core/request";
-import {randomUUID} from "crypto";
+import { ApiComponents, ApiError, BadRequestError, RequestPart } from '../../src/client/generated';
+import { getCapableAccountId, hasCapability } from '../utils/capable-accounts';
+import { randomUUID } from 'crypto';
 
 JSONSchemaFaker.option('requiredOnly', true);
 
 describe('Test request bodies missing one required property', () => {
   const client = new ApiClient();
-  const postEndpoints = getAllEndpointSchemas().filter(
-      (op) => {
-        const [capability] = op.schema.tags
-        return op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
-      }
-  );
+  const postEndpoints = getAllEndpointSchemas().filter((op) => {
+    const [capability] = op.schema.tags;
+    return (
+      op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
+    );
+  });
 
   let accountId: string;
 
   describe.each(postEndpoints)('$method $url', ({ operationId, url, schema }: EndpointSchema) => {
-    const [component] = schema.tags
-    accountId = getCapableAccountId(component as keyof ApiComponents)
+    const [component] = schema.tags;
+    accountId = getCapableAccountId(component as keyof ApiComponents);
 
     // Test multiple times due to the randomness of the generated payloads
     describe.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])('Attempt %d', () => {

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -2,19 +2,31 @@ import _ from 'lodash';
 import { JsonValue } from 'type-fest';
 import ApiClient from '../../src/client';
 import { JSONSchemaFaker, Schema } from 'json-schema-faker';
-import { EndpointSchema, getAllEndpointSchemas } from '../../src/schemas';
+import {EndpointSchema, getAllEndpointSchemas} from '../../src/schemas';
 import { deleteDeepProperty, getPropertyPaths } from '../property-extraction';
-import { ApiError, BadRequestError, RequestPart } from '../../src/client/generated';
+import {ApiComponents, ApiError, BadRequestError, RequestPart} from '../../src/client/generated';
+import {AssetsDirectory} from "../utils/assets-directory";
+import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
+import {getRequestBody} from "../../src/client/generated/core/request";
+import {randomUUID} from "crypto";
 
 JSONSchemaFaker.option('requiredOnly', true);
 
 describe('Test request bodies missing one required property', () => {
   const client = new ApiClient();
   const postEndpoints = getAllEndpointSchemas().filter(
-    (op) => op.method === 'POST' && op.schema.body
+      (op) => {
+        const [capability] = op.schema.tags
+        return op.method === 'POST' && op.schema.body && hasCapability(capability as keyof ApiComponents)
+      }
   );
 
+  let accountId: string;
+
   describe.each(postEndpoints)('$method $url', ({ operationId, url, schema }: EndpointSchema) => {
+    const [component] = schema.tags
+    accountId = getCapableAccountId(component as keyof ApiComponents)
+
     // Test multiple times due to the randomness of the generated payloads
     describe.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])('Attempt %d', () => {
       const goodBody = JSONSchemaFaker.generate(schema.body as Schema);
@@ -24,7 +36,7 @@ describe('Test request bodies missing one required property', () => {
         const operationFunction = client[schema.tags[0]]?.[operationId].bind(client);
 
         try {
-          await operationFunction({ requestBody });
+          await operationFunction({ requestBody, accountId });
         } catch (err) {
           if (err instanceof ApiError) {
             return err;
@@ -41,6 +53,11 @@ describe('Test request bodies missing one required property', () => {
           beforeAll(async () => {
             const badBody = _.cloneDeep(goodBody);
             deleteDeepProperty(badBody, propertyPath);
+
+            if (badBody?.['idempotencyKey']) {
+              badBody['idempotencyKey'] = randomUUID();
+            }
+
             apiError = await sendRequest(badBody);
           });
 

--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -52,7 +52,7 @@ describe('Test request bodies missing one required property', () => {
             const badBody = _.cloneDeep(goodBody);
             deleteDeepProperty(badBody, propertyPath);
 
-            if (Object.prototype.hasOwnProperty.call(badBody, 'idempotencyKey')) {
+            if (badBody.hasOwnProperty('idempotencyKey')) {
               badBody['idempotencyKey'] = randomUUID();
             }
 


### PR DESCRIPTION
The idempotency key was not being refreshed on subsequent requests, this would cause an unexpected failure.

Certain capabilities that are not supported by the server, should not be tested.