### PR TITLE
run only tests that pass capabilities

### DIFF
--- a/v2/api-validator/tests/server-tests/pagination-params.test.ts
+++ b/v2/api-validator/tests/server-tests/pagination-params.test.ts
@@ -10,7 +10,7 @@ import {
   PaginationStartingAfter,
   RequestPart,
 } from '../../src/client/generated';
-import {getCapableAccountId, hasCapability} from "../utils/capable-accounts";
+import { getCapableAccountId, hasCapability } from '../utils/capable-accounts';
 
 type PaginationParams = {
   limit?: PaginationLimit;
@@ -33,7 +33,7 @@ describe('Pagination params tests', () => {
 
       try {
         if (params !== undefined) {
-          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents)
+          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
         }
       } catch (e) {
         // no capable account, use faked account

--- a/v2/api-validator/tests/server-tests/pagination-params.test.ts
+++ b/v2/api-validator/tests/server-tests/pagination-params.test.ts
@@ -31,12 +31,8 @@ describe('Pagination params tests', () => {
       const querystring = fakeObject(schema.querystring);
       const params = fakeObject(schema.params);
 
-      try {
-        if (params !== undefined) {
-          params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
-        }
-      } catch (e) {
-        // no capable account, use faked account
+      if (params !== undefined && Object.prototype.hasOwnProperty.call(params, 'accountId')) {
+        params.accountId = getCapableAccountId(schema.tags[0] as keyof ApiComponents);
       }
 
       try {


### PR DESCRIPTION
The account ID used for tests should be one of the capable accounts, otherwise account ID validation might trigger before the actual validation being tested.