### PR TITLE
fix: automatically delete when there is a slash at the end of baseurl

### DIFF
--- a/v2/api-validator/src/client/generated/core/request.ts
+++ b/v2/api-validator/src/client/generated/core/request.ts
@@ -12,6 +12,7 @@ import type { ApiResult } from './ApiResult';
 import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
+import { removeTrailingSlash } from '../../../url-helpers';
 
 export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null;
@@ -101,7 +102,8 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
             return substring;
         });
 
-    const url = `${config.BASE}${path}`;
+    const prefix = removeTrailingSlash(config.BASE);
+    const url = `${prefix}${path}`;
     if (options.query) {
         return `${url}${getQueryString(options.query)}`;
     }

--- a/v2/api-validator/src/url-helpers.ts
+++ b/v2/api-validator/src/url-helpers.ts
@@ -2,7 +2,7 @@ import config from './config';
 
 export function getServerUrlPathPrefix(): string {
   const prefix = new URL(config.get('client.serverBaseUrl')).pathname;
-  return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  return removeTrailingSlash(prefix);
 }
 
 export function removeServerPathPrefixFromRelativeUrl(relativeUrl: string): string {
@@ -14,4 +14,8 @@ export function getRelativeUrlWithoutPathPrefix(absoluteUrl: string): string {
   const parsedUrl = new URL(absoluteUrl);
   const relativeUrl = parsedUrl.pathname + parsedUrl.search;
   return removeServerPathPrefixFromRelativeUrl(relativeUrl);
+}
+
+export function removeTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path.slice(0, -1) : path;
 }


### PR DESCRIPTION
When there is a trailing slash in the serverBaseUrl, we will get a URL like: http://0.0.0.0:8000//xxx, but modern HTTP servers can handle requests with extra slashes correctly. Even though we used the incorrect URL and signature (URL affects the signature result), we were able to access the backend service correctly, resulting in a discrepancy in the signature.