### PR TITLE
fix: move collateral tests initiations to beforeAll hook

### DIFF
--- a/v2/api-validator/tests/server-tests/collateral/deposit-address.test.ts
+++ b/v2/api-validator/tests/server-tests/collateral/deposit-address.test.ts
@@ -14,12 +14,15 @@ import config from '../../../src/config';
 const noCollateralCapability = !hasCapability('collateral');
 
 describe.skipIf(noCollateralCapability)('Collateral Deposit Address', () => {
-  const client = new Client();
-  const accountId: string = getCapableAccountId('collateral');
-  const collateralId: string = config.get('collateral.collateralAccount.accountId');
+  let client: Client;
+  let accountId: string;
+  let collateralId: string;
   let assetId: string;
 
   beforeAll(async () => {
+    client = new Client();
+    accountId = getCapableAccountId('collateral');
+    collateralId = config.get('collateral.collateralAccount.accountId');
     const agetAssetsResults = await client.capabilities.getAdditionalAssets({});
     assetId = agetAssetsResults.assets[0]?.id;
   });

--- a/v2/api-validator/tests/server-tests/collateral/deposit.test.ts
+++ b/v2/api-validator/tests/server-tests/collateral/deposit.test.ts
@@ -17,15 +17,18 @@ import Client from '../../../src/client';
 const noCollateralCapability = !hasCapability('collateral');
 
 describe.skipIf(noCollateralCapability)('Collateral Deposit', () => {
-  const client: Client = new Client();
-  const accountId: string = getCapableAccountId('collateral');
-  const collateralId: string = config.get('collateral.collateralAccount.accountId');
+  let client: Client;
+  let accountId: string;
+  let collateralId: string;
   const fireblocksIntentId = uuid();
   let assetId: string;
 
   beforeAll(async () => {
     const agetAssetsResults = await client.capabilities.getAdditionalAssets({});
     assetId = agetAssetsResults.assets[0]?.id;
+    client = new Client();
+    accountId = getCapableAccountId('collateral');
+    collateralId = config.get('collateral.collateralAccount.accountId');
   });
 
   describe('Register collateral deposit transaction (add collateral) & fetch by collateralTxId', () => {

--- a/v2/api-validator/tests/server-tests/collateral/settlement.test.ts
+++ b/v2/api-validator/tests/server-tests/collateral/settlement.test.ts
@@ -12,9 +12,15 @@ import Client from '../../../src/client';
 const noCollateralCapability = !hasCapability('collateral');
 
 describe.skipIf(noCollateralCapability)('Collateral Settlements', () => {
-  const client: Client = new Client();
-  const accountId: string = getCapableAccountId('collateral');
-  const collateralId: string = config.get('collateral.collateralAccount.accountId');
+  let client: Client;
+  let accountId: string;
+  let collateralId: string;
+
+  beforeAll(async () => {
+    client = new Client();
+    accountId = getCapableAccountId('collateral');
+    collateralId = config.get('collateral.collateralAccount.accountId');
+  });
 
   describe('Check full settlement flow', () => {
     let settlementVersion: string;

--- a/v2/api-validator/tests/server-tests/collateral/withdrawal.test.ts
+++ b/v2/api-validator/tests/server-tests/collateral/withdrawal.test.ts
@@ -19,12 +19,19 @@ import { v4 as uuid } from 'uuid';
 const noCollateralCapability = !hasCapability('collateral');
 
 describe.skipIf(noCollateralCapability)('Collateral Withdrawal', () => {
-  const client: Client = new Client();
-  const accountId: string = getCapableAccountId('collateral');
-  const collateralId = config.get('collateral.collateralAccount.accountId');
-  const collateralTxId = `0.${uuid()}.${collateralId}`;
+  let client: Client;
+  let accountId: string;
+  let collateralId: string;
+  let collateralTxId: string;
+
   const fireblocksIntentId = uuid();
   const intentApprovalRequest: IntentApprovalRequest = { fireblocksIntentId: fireblocksIntentId };
+  beforeAll(async () => {
+    client = new Client();
+    accountId = getCapableAccountId('collateral');
+    collateralId = config.get('collateral.collateralAccount.accountId');
+    collateralTxId = `0.${uuid()}.${collateralId}`;
+  });
 
   describe('Create collateral withdrawal transaction (remove collateral) & fetch by collateralTxId ', () => {
     const address: PublicBlockchainAddress[] = JSON.parse(


### PR DESCRIPTION
Same as https://github.com/fireblocks/fireblocks-network-link/pull/101

Collateral tests are broken for servers without the collateral capability. This is because the definitions within the describe are called even if the test is skipped. In this case, the call to getCapableAccountId fails because no accounts have that capability. Moving that call to the beforeAll hook fixes this.