### PR TITLE
Update fb-provider-transfer-api.yaml

### DIFF
--- a/v2/openapi/fb-provider-transfer-api.yaml
+++ b/v2/openapi/fb-provider-transfer-api.yaml
@@ -394,7 +394,7 @@ paths:
     post:
       operationId: createFiatWithdrawal
       summary: Create new fiat withdrawal
-      description: Should reject any non fiat withdrawal request.
+      description: Should reject any non fiat withdrawal request. Only IbanAddress is currently supported. SwiftAddress is not yet a valid destination object. 
       tags: [ transfersFiat ]
       parameters:
         - $ref: '#/x-header-params/X-FBAPI-KEY'


### PR DESCRIPTION
Updated createFiatWithdrawal description to note that SwiftAddress is not yet supported