### PR TITLE
Fix Empty post capabilities array

### DIFF
--- a/v2/api-validator/tests/server-tests/bad-request-body.test.ts
+++ b/v2/api-validator/tests/server-tests/bad-request-body.test.ts
@@ -21,8 +21,9 @@ describe('Test request bodies missing one required property', () => {
 
   let accountId: string;
 
-  if (postEndpoints.length > 0) {
-    describe.each(postEndpoints)('$method $url', ({ operationId, url, schema }: EndpointSchema) => {
+  describe.skipIf(postEndpoints.length === 0).each(postEndpoints)(
+    '$method $url',
+    ({ operationId, url, schema }: EndpointSchema) => {
       const [component] = schema.tags;
       accountId = getCapableAccountId(component as keyof ApiComponents);
 
@@ -73,8 +74,8 @@ describe('Test request bodies missing one required property', () => {
           });
         }
       });
-    });
-  }
+    }
+  );
 });
 
 // When missing a properties appearing in oneOf, the server might report as if


### PR DESCRIPTION
Fix bug with the API Validator where only the basic capabilities 'balances' and 'accounts' are implemented, containing only 'GET' endpoints. The API Validator is throwing an error due to the 'postEndpoints' array being empty.